### PR TITLE
add `namespace` to `build.gradle`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.staking_power.ios_insecure_screen_detector"
     compileSdkVersion 30
 
     defaultConfig {


### PR DESCRIPTION
I met an issue building an old project using this package which needed the `namespace` to be added inside `build.gradle` file so I've added.